### PR TITLE
Add additional thrifty control to check unused NAT gateways. Closes #38

### DIFF
--- a/controls/network.sp
+++ b/controls/network.sp
@@ -26,7 +26,7 @@ control "unattached_eips" {
 }
 
 control "unused_vpc_nat_gateways" {
-  title         = "VPC NAT gateway available and unused should be reviewed"
+  title         = "Unused NAT gateways should be reviewed"
   description   = "NAT Gateway is charged on an hourly basis once it is provisioned and available, check why these are available but not used."
   sql           = query.vpc_nat_gateway_unused.sql
   severity      = "low"

--- a/controls/network.sp
+++ b/controls/network.sp
@@ -16,7 +16,7 @@ benchmark "network" {
 }
 
 control "unattached_eips" {
-  title         = "Are there any unattached Elastic IP addresses (EIP)?"
+  title         = "Unattached elastic IP addresses (EIPs) should be released"
   description   = "Unattached Elastic IPs are charged by AWS, they should be released."
   sql           = query.unattached_eips.sql
   severity      = "low"
@@ -26,8 +26,8 @@ control "unattached_eips" {
 }
 
 control "unused_vpc_nat_gateways" {
-  title         = "Unused NAT gateways should be reviewed"
-  description   = "NAT Gateway is charged on an hourly basis once it is provisioned and available, check why these are available but not used."
+  title         = "Unused NAT gateways should be deleted"
+  description   = "NAT gateway are charged on an hourly basis once they are provisioned and available, so unused gateways should be deleted."
   sql           = query.vpc_nat_gateway_unused.sql
   severity      = "low"
   tags = merge(local.vpc_common_tags, {

--- a/controls/network.sp
+++ b/controls/network.sp
@@ -7,10 +7,11 @@ locals {
 benchmark "network" {
   title         = "Networking Checks"
   description   = "Thrifty developers ensure delete unused network resources."
-  documentation = file("./controls/docs/network.md") #TODO
+  documentation = file("./controls/docs/network.md")
   tags          = local.vpc_common_tags
   children = [
-    control.unattached_eips
+    control.unattached_eips,
+    control.unused_vpc_nat_gateways
   ]
 }
 
@@ -24,4 +25,12 @@ control "unattached_eips" {
   })
 }
 
-//TODO Add unattached Gateways
+control "unused_vpc_nat_gateways" {
+  title         = "VPC NAT gateway available and unused should be reviewed"
+  description   = "NAT Gateway is charged on an hourly basis once it is provisioned and available, check why these are available but not used."
+  sql           = query.vpc_nat_gateway_unused.sql
+  severity      = "low"
+  tags = merge(local.vpc_common_tags, {
+    class = "unused"
+  })
+}

--- a/query/vpc/vpc_nat_gateway_unused.sql
+++ b/query/vpc/vpc_nat_gateway_unused.sql
@@ -1,0 +1,29 @@
+with instance_data as (
+  select
+    instance_id,
+    subnet_id,
+    instance_state
+  from
+    aws_ec2_instance
+)
+select
+  -- Required Columns
+  nat.arn as resource,
+  case
+    when nat.state <> 'available' then 'alarm'
+    when i.subnet_id is null then 'alarm'
+    when i.instance_state <> 'running' then 'alarm'
+    else 'ok'
+  end as status,
+  case
+    when nat.state <> 'available' then nat.title || ' in ' || nat.state || ' state.'
+    when i.subnet_id is null then nat.title || ' not in-use.'
+    when i.instance_state <> 'running' then nat.title || ' associated with ' || i.instance_id || ', which is in ' || i.instance_state || ' state.'
+    else nat.title || ' in-use.'
+  end as reason,
+  -- Additional Dimensions
+  nat.region,
+  nat.account_id
+from
+  aws_vpc_nat_gateway as nat
+  left join instance_data as i on nat.subnet_id = i.subnet_id;


### PR DESCRIPTION
### Checklist
- [x] #38

```
+ VPC NAT gateway available and unused should be reviewed ........................................................................................................................... 1 / 2 [==========]
  | 
  OK   : nat-056d9f37189f71a58 in-use. .......................................................................................................................................... us-east-1 123456789012
  ALARM: nat-0b32f151f3b33c9b7 not in-use. ...................................................................................................................................... us-east-1 123456789012
```