### PR TITLE
Fix ec2_classic_lb_unused query to use the latest format of the aws_ec2_classic_load_balancer table

### DIFF
--- a/query/ec2/ec2_classic_lb_unused.sql
+++ b/query/ec2/ec2_classic_lb_unused.sql
@@ -1,12 +1,12 @@
 select
   arn as resource,
   case
-    when instances is null then 'alarm'
-    else 'ok'
+    when jsonb_array_length(instances) > 0 then 'ok'
+    else 'alarm'
   end as status,
   case
-    when instances is null then title || ' has no instances registered.'
-    else title || ' has registered instances.'
+    when jsonb_array_length(instances) > 0 then title || ' has registered instances.'
+    else title || ' has no instances registered.'
   end as reason,
   region,
   account_id


### PR DESCRIPTION
Similar to https://github.com/turbot/steampipe-mod-aws-thrifty/pull/102, this applies a similar fix to the `ec2_classic_lb_unused` query.