### PR TITLE
Graviton2 to Graviton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@ _What's new?_
   - Secrets Manager Checks (`steampipe check benchmark.secretsmanager`) ([#85](https://github.com/turbot/steampipe-mod-aws-thrifty/pull/85))
 - New controls added:
   - ec2_instance_older_generation ([#79](https://github.com/turbot/steampipe-mod-aws-thrifty/pull/79))
-  - lambda_function_with_graviton ([#82](https://github.com/turbot/steampipe-mod-aws-thrifty/pull/82))
+  - lambda_function_with_graviton2 ([#82](https://github.com/turbot/steampipe-mod-aws-thrifty/pull/82))
 
 _Enhancements_
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@ _What's new?_
   - Secrets Manager Checks (`steampipe check benchmark.secretsmanager`) ([#85](https://github.com/turbot/steampipe-mod-aws-thrifty/pull/85))
 - New controls added:
   - ec2_instance_older_generation ([#79](https://github.com/turbot/steampipe-mod-aws-thrifty/pull/79))
-  - lambda_function_with_graviton2 ([#82](https://github.com/turbot/steampipe-mod-aws-thrifty/pull/82))
+  - lambda_function_with_graviton ([#82](https://github.com/turbot/steampipe-mod-aws-thrifty/pull/82))
 
 _Enhancements_
 

--- a/controls/ec2.sp
+++ b/controls/ec2.sp
@@ -358,8 +358,8 @@ control "ec2_instance_older_generation" {
 }
 
 control "ec2_instance_with_graviton" {
-  title       = "EC2 instances without graviton2 processor should be reviewed"
-  description = "With graviton2 processor (arm64 - 64-bit ARM architecture), you can save money in two ways. First, your functions run more efficiently due to the Graviton2 architecture. Second, you pay less for the time that they run. In fact, Lambda functions powered by Graviton2 are designed to deliver up to 19 percent better performance at 20 percent lower cost."
+  title       = "EC2 instances without graviton processor should be reviewed"
+  description = "With graviton processor (arm64 - 64-bit ARM architecture), you can save money in two ways. First, your functions run more efficiently due to the Graviton architecture. Second, you pay less for the time that they run. In fact, Lambda functions powered by Graviton are designed to deliver up to 19 percent better performance at 20 percent lower cost."
   severity    = "low"
 
   tags = merge(local.ec2_common_tags, {
@@ -376,8 +376,8 @@ control "ec2_instance_with_graviton" {
       end as status,
       case
         when platform = 'windows' then title || ' is windows type machine.'
-        when architecture = 'arm64' then title || ' is using Graviton2 processor.'
-        else title || ' is not using Graviton2 processor.'
+        when architecture = 'arm64' then title || ' is using Graviton processor.'
+        else title || ' is not using Graviton processor.'
       end as reason
       ${local.tag_dimensions_sql}
       ${local.common_dimensions_sql}

--- a/controls/ecs.sp
+++ b/controls/ecs.sp
@@ -32,8 +32,8 @@ benchmark "ecs" {
 }
 
 control "ecs_cluster_container_instance_with_graviton" {
-  title       = "ECS cluster container instances without graviton2 processor should be reviewed"
-  description = "With graviton2 processor (arm64 - 64-bit ARM architecture), you can save money in two ways. First, your functions run more efficiently due to the Graviton2 architecture. Second, you pay less for the time that they run. In fact, Lambda functions powered by Graviton2 are designed to deliver up to 19 percent better performance at 20 percent lower cost."
+  title       = "ECS cluster container instances without graviton processor should be reviewed"
+  description = "With graviton processor (arm64 - 64-bit ARM architecture), you can save money in two ways. First, your functions run more efficiently due to the Graviton architecture. Second, you pay less for the time that they run. In fact, Lambda functions powered by Graviton are designed to deliver up to 19 percent better performance at 20 percent lower cost."
   severity    = "low"
 
   tags = merge(local.ecs_common_tags, {
@@ -50,8 +50,8 @@ control "ecs_cluster_container_instance_with_graviton" {
       end as status,
       case
         when i.platform = 'windows' then i.title || ' is windows type machine.'
-        when i.architecture = 'arm64' then i.title || ' is using Graviton2 processor.'
-        else i.title || ' is not using Graviton2 processor.'
+        when i.architecture = 'arm64' then i.title || ' is using Graviton processor.'
+        else i.title || ' is not using Graviton processor.'
       end as reason
       ${replace(local.tag_dimensions_qualifier_sql, "__QUALIFIER__", "c.")}
       ${replace(local.common_dimensions_qualifier_sql, "__QUALIFIER__", "c.")}

--- a/controls/eks.sp
+++ b/controls/eks.sp
@@ -18,8 +18,8 @@ benchmark "eks" {
 }
 
 control "eks_node_group_with_graviton" {
-  title       = "EKS node groups without graviton2 processor should be reviewed"
-  description = "With graviton2 processor (arm64 - 64-bit ARM architecture), you can save money in two ways. First, your functions run more efficiently due to the Graviton2 architecture. Second, you pay less for the time that they run. In fact, Lambda functions powered by Graviton2 are designed to deliver up to 19 percent better performance at 20 percent lower cost."
+  title       = "EKS node groups without graviton processor should be reviewed"
+  description = "With graviton processor (arm64 - 64-bit ARM architecture), you can save money in two ways. First, your functions run more efficiently due to the Graviton architecture. Second, you pay less for the time that they run. In fact, Lambda functions powered by Graviton are designed to deliver up to 19 percent better performance at 20 percent lower cost."
   severity    = "low"
 
   tags = merge(local.eks_common_tags, {
@@ -69,11 +69,11 @@ control "eks_node_group_with_graviton" {
     end as status,
     case
       when ami_type = 'CUSTOM%' and a.platform <> 'linux' then title || ' is not using linux platform.'
-      when ami_type = 'CUSTOM%' and a.architecture = 'x86_64' and a.platform = 'linux' then title || ' is using Graviton2 processor.'
-      when ami_type = 'CUSTOM%' and a.architecture <> 'arm_64' and a.platform = 'linux' then title || ' is not using Graviton2 processor.'
+      when ami_type = 'CUSTOM%' and a.architecture = 'x86_64' and a.platform = 'linux' then title || ' is using Graviton processor.'
+      when ami_type = 'CUSTOM%' and a.architecture <> 'arm_64' and a.platform = 'linux' then title || ' is not using Graviton processor.'
       when ami_type not like 'AL2_%' then title || ' is not using linux platform.'
-      when ami_type = 'AL2_ARM_64' then title || ' is using Graviton2 processor.'
-      else title || ' is not using Graviton2 processor.'
+      when ami_type = 'AL2_ARM_64' then title || ' is using Graviton processor.'
+      else title || ' is not using Graviton processor.'
     end as reason
     ${local.tag_dimensions_sql}
     ${local.common_dimensions_sql}

--- a/controls/lambda.sp
+++ b/controls/lambda.sp
@@ -12,7 +12,7 @@ benchmark "lambda" {
   children = [
     control.lambda_function_excessive_timeout,
     control.lambda_function_high_error_rate,
-    control.lambda_function_with_graviton2
+    control.lambda_function_with_graviton
   ]
 
   tags = merge(local.lambda_common_tags, {
@@ -98,9 +98,9 @@ control "lambda_function_excessive_timeout" {
   EOQ
 }
 
-control "lambda_function_with_graviton2" {
-  title       = "Are there any lambda functions without graviton2 processor?"
-  description = "With graviton2 processor (arm64 - 64-bit ARM architecture), you can save money in two ways. First, your functions run more efficiently due to the Graviton2 architecture. Second, you pay less for the time that they run. In fact, Lambda functions powered by Graviton2 are designed to deliver up to 19 percent better performance at 20 percent lower cost."
+control "lambda_function_with_graviton" {
+  title       = "Are there any lambda functions without graviton processor?"
+  description = "With graviton processor (arm64 - 64-bit ARM architecture), you can save money in two ways. First, your functions run more efficiently due to the Graviton architecture. Second, you pay less for the time that they run. In fact, Lambda functions powered by Graviton are designed to deliver up to 19 percent better performance at 20 percent lower cost."
   severity    = "low"
 
   tags = merge(local.lambda_common_tags, {
@@ -115,8 +115,8 @@ control "lambda_function_with_graviton2" {
         else 'alarm'
       end as status,
       case
-        when architecture = 'arm64' then title || ' is using Graviton2 processor.'
-        else title || ' is not using Graviton2 processor.'
+        when architecture = 'arm64' then title || ' is using Graviton processor.'
+        else title || ' is not using Graviton processor.'
       end as reason
       ${local.tag_dimensions_sql}
       ${local.common_dimensions_sql}

--- a/controls/rds.sp
+++ b/controls/rds.sp
@@ -214,8 +214,8 @@ control "rds_db_low_utilization" {
 }
 
 control "rds_db_instance_with_graviton" {
-  title       = "RDS DB instances without graviton2 processor should be reviewed"
-  description = "With graviton2 processor (arm64 - 64-bit ARM architecture), you can save money in two ways. First, your functions run more efficiently due to the Graviton2 architecture. Second, you pay less for the time that they run. In fact, Lambda functions powered by Graviton2 are designed to deliver up to 19 percent better performance at 20 percent lower cost."
+  title       = "RDS DB instances without graviton processor should be reviewed"
+  description = "With graviton processor (arm64 - 64-bit ARM architecture), you can save money in two ways. First, your functions run more efficiently due to the Graviton architecture. Second, you pay less for the time that they run. In fact, Lambda functions powered by Graviton are designed to deliver up to 19 percent better performance at 20 percent lower cost."
   severity    = "low"
 
   tags = merge(local.rds_common_tags, {
@@ -230,8 +230,8 @@ control "rds_db_instance_with_graviton" {
         else 'alarm'
       end as status,
       case
-        when class like 'db.%g%.%' then title || ' is using Graviton2 processor.'
-        else title || ' is not using Graviton2 processor.'
+        when class like 'db.%g%.%' then title || ' is using Graviton processor.'
+        else title || ' is not using Graviton processor.'
       end as reason
       ${local.tag_dimensions_sql}
       ${local.common_dimensions_sql}


### PR DESCRIPTION
AWS Graviton is a family of processors designed to deliver the best price performance for your cloud workloads running in Amazon Elastic Compute Cloud (Amazon EC2).
Whilst Graviton2 is mentioned in the code Graviton3 processes have now been released. To future proof the code this PR changes references from [G/g]raviton2 to simply [G/g]raviton